### PR TITLE
Add option for specifying Bootstrap version

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = (opts = { }) => {
     postcssPlugin: 'postcss-understrap-palette-generator',
     prepare (result) {
       let colorJson = opts.defaults || {};
-      let bs4 = opts.bs4 || true;
+      let bs4 = (typeof opts.bs4 === 'undefined') ? true : opts.bs4;
       let colorInfix = bs4 ? '' : 'bs-';
       let colors = opts.colors || [
         `--${colorInfix}blue`,

--- a/index.js
+++ b/index.js
@@ -6,37 +6,41 @@ module.exports = (opts = { }) => {
 
   return {
     postcssPlugin: 'postcss-understrap-palette-generator',
-	prepare (result) {
-		let colorJson = opts.defaults || {};
-		let colors = opts.colors || [
-			"--blue",
-			"--indigo",
-			"--purple",
-			"--pink",
-			"--red",
-			"--orange",
-			"--yellow",
-			"--green",
-			"--teal",
-			"--cyan",
-			"--white",
-			"--gray",
-			"--gray-dark"
-		];
-		return {
-			Declaration (decl) {
-				if ( colors.indexOf( decl.prop ) > -1 ) {
-					colorJson[decl.prop] = decl.value;
-				}
-			},
-			OnceExit () {
-        if (!(Object.keys(colorJson).length === 0)){
-          fs.writeFile('inc/editor-color-palette.json', JSON.stringify(colorJson), function(){});
+    prepare (result) {
+      let colorJson = opts.defaults || {};
+      let bs4 = opts.bs4 || true;
+      let colorInfix = bs4 ? '' : 'bs-';
+      let colors = opts.colors || [
+        `--${colorInfix}blue`,
+        `--${colorInfix}indigo`,
+        `--${colorInfix}purple`,
+        `--${colorInfix}pink`,
+        `--${colorInfix}red`,
+        `--${colorInfix}orange`,
+        `--${colorInfix}yellow`,
+        `--${colorInfix}green`,
+        `--${colorInfix}teal`,
+        `--${colorInfix}cyan`,
+        `--${colorInfix}white`,
+        `--${colorInfix}gray`,
+        `--${colorInfix}gray-dark`
+      ];
+
+      return {
+        Declaration (decl) {
+          if ( colors.indexOf( decl.prop ) > -1 ) {
+            colorJson[decl.prop] = decl.value;
+          }
+        },
+        OnceExit () {
+          if (!(Object.keys(colorJson).length === 0)){
+            let fileInfix = bs4 ? '-bootstrap4' : '';
+            fs.writeFile(`inc/editor-color-palette${fileInfix}.json`, JSON.stringify(colorJson), function(){});
+          }
+          return colorJson;
         }
-				return colorJson;
-			}
-		}
-	}
+      }
+    }
   }
 }
 module.exports.postcss = true


### PR DESCRIPTION
This PR
- adds the boolean option `bs4` which should be set to true if the Bootstrap version is 4 and should be set to false if the Bootstrap version is 5. Default is true. 
- adds the BSv5 infix to the default colors if `bs4==false`.
- adds a `-bootstrap4` suffix to the name of the json output file if `bs4==true`.

Changing the name of the json file is necessary to both accommodate correct default colors for Bootstrap 4 and Bootstrap 5. Currently calling `npm run css-postcss` overrides the json files produced by a call to `npm run css-postcss-bs4` and vice versa. Necessary changes to the Understrap theme will be made in a PR in the [theme's repository](https://github.com/understrap/understrap) referencing this PR. Also, this is a breaking change.